### PR TITLE
Fix exam stage name in stage README

### DIFF
--- a/stages/README.md
+++ b/stages/README.md
@@ -26,7 +26,7 @@ Students are presented with Java code snippets and must predict their output. Af
 | **Stage 5** | Object-Oriented Programming | Classes, objects, inheritance, encapsulation               |
 | **Stage 6** | OOP & Inheritance           | Advanced OOP concepts, polymorphism, abstract classes      |
 | **Stage 7** | Advanced Data Structures    | Stacks, queues, sets, abstract data types                  |
-| **Exam Stage** | Past Exam Topics           | Mixed questions from intro221a exam |
+| **Exam221a Stage** | Past Exam Topics           | Mixed questions from intro221a exam |
 
 ### Stage Progression
 
@@ -52,6 +52,7 @@ stages/
 ├── stage_5.java              # Object-oriented programming
 ├── stage_6.java              # OOP and inheritance
 ├── stage_7.java              # Advanced data structures
+├── exam221a_stage.java       # Past exam questions
 └── play_game.bat             # Windows batch file to run stages
 ```
 
@@ -181,7 +182,7 @@ Each stage is designed around specific learning objectives:
 - Set operations and uniqueness
 - Iterator pattern usage
 
-#### **Exam Stage: Past Exam Topics**
+#### **Exam221a Stage: Past Exam Topics**
 
 - Review graph partitions and edge checks
 - Balanced parentheses counting


### PR DESCRIPTION
## Summary
- update table to reference `Exam221a Stage`
- add `exam221a_stage.java` to the file structure listing
- revise section heading for the exam stage

## Testing
- `grep -n "Exam221a" -n stages/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68630dcd8f28832384a905672dba2058